### PR TITLE
Remove the TLS certificate validation not implemented notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An opinionated wrapper for Vellum's fork of Alpine's apk-tools that has been ada
 ## Installation
 
 ```sh
-wget -O bootstrap.sh https://github.com/vellum-dev/vellum-cli/releases/latest/download/bootstrap.sh
+wget --no-check-certificate -O bootstrap.sh https://github.com/vellum-dev/vellum-cli/releases/latest/download/bootstrap.sh
 echo "3f2a4c721fa71919f747cec8047d34305179bf069be20db78ae98041525f2da4  bootstrap.sh" | sha256sum -c && bash bootstrap.sh
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -99,7 +99,7 @@ if [ -n "$OFFLINE_DIR" ]; then
     cp "$OFFLINE_DIR/apk-$APK_ARCH" "$VELLUM_ROOT/bin/apk.vellum"
 else
     echo "Downloading apk.vellum..."
-    wget -q "$VELLUM_APK_RELEASES/apk-$APK_ARCH" -O "$VELLUM_ROOT/bin/apk.vellum"
+    wget -q --no-check-certificate "$VELLUM_APK_RELEASES/apk-$APK_ARCH" -O "$VELLUM_ROOT/bin/apk.vellum"
 fi
 case "$APK_ARCH" in
     aarch64) verify_sha256 "$VELLUM_ROOT/bin/apk.vellum" "$APK_AARCH64_SHA256" ;;
@@ -116,8 +116,8 @@ if [ -n "$OFFLINE_DIR" ]; then
 else
     echo "Downloading vellum..."
     case "$APK_ARCH" in
-        aarch64) wget -q "$VELLUM_CLI_RELEASES/vellum-linux-arm64" -O "$VELLUM_ROOT/bin/vellum" ;;
-        armv7)   wget -q "$VELLUM_CLI_RELEASES/vellum-linux-armv7" -O "$VELLUM_ROOT/bin/vellum" ;;
+        aarch64) wget -q --no-check-certificate "$VELLUM_CLI_RELEASES/vellum-linux-arm64" -O "$VELLUM_ROOT/bin/vellum" ;;
+        armv7)   wget -q --no-check-certificate "$VELLUM_CLI_RELEASES/vellum-linux-armv7" -O "$VELLUM_ROOT/bin/vellum" ;;
     esac
 fi
 case "$APK_ARCH" in
@@ -131,7 +131,7 @@ if [ -n "$OFFLINE_DIR" ]; then
     cp "$OFFLINE_DIR/packages.rsa.pub" "$VELLUM_ROOT/etc/apk/keys/packages.rsa.pub"
 else
     echo "Downloading signing key..."
-    wget -q "$VELLUM_PACKAGES_REPO/keys/packages.rsa.pub" -O "$VELLUM_ROOT/etc/apk/keys/packages.rsa.pub"
+    wget -q --no-check-certificate "$VELLUM_PACKAGES_REPO/keys/packages.rsa.pub" -O "$VELLUM_ROOT/etc/apk/keys/packages.rsa.pub"
 fi
 verify_sha256 "$VELLUM_ROOT/etc/apk/keys/packages.rsa.pub" "$SIGNING_KEY_SHA256"
 


### PR DESCRIPTION
Before:
```
Connecting to github.com (140.82.121.4:443)
wget: note: TLS certificate validation not implemented
Connecting to github.com (140.82.121.4:443)
Connecting to release-assets.githubusercontent.com (185.199.110.133:443)
saving to 'bootstrap.sh'
bootstrap.sh         100% |*...*|  7212  0:00:00 ETA
'bootstrap.sh' saved
bootstrap.sh: OK
Installing vellum...
Downloading apk.vellum...
wget: note: TLS certificate validation not implemented
Downloading vellum...
wget: note: TLS certificate validation not implemented
Downloading signing key...
wget: note: TLS certificate validation not implemented
Generating local signing key...
Configuring repositories...
Initializing local repository...
Initializing apk database...
OK: 4163 KiB in 5 packages
Registering vellum package...
OK: 4163 KiB in 5 packages
Updating package index...
 [/home/root/.vellum/local-repo]
 [https://packages.vellum.delivery]
OK: 173 distinct packages available
Installing mount-utils...
OK: 4163 KiB in 5 packages
Installing bash completion...
OK: 4163 KiB in 5 packages
PATH already configured in /home/root/.bashrc

Vellum installed successfully!
Run 'source ~/.bashrc' or start a new shell to use vellum.
```

After:
```
Connecting to github.com (140.82.121.4:443)
Connecting to github.com (140.82.121.4:443)
Connecting to release-assets.githubusercontent.com (185.199.108.133:443)
saving to 'bootstrap.sh'
bootstrap.sh         100% |*...*|  7304  0:00:00 ETA
'bootstrap.sh' saved
bootstrap.sh: OK
Installing vellum...
Downloading apk.vellum...
Downloading vellum...
Downloading signing key...
Generating local signing key...
Configuring repositories...
Initializing local repository...
Initializing apk database...
OK: 4163 KiB in 5 packages
Registering vellum package...
OK: 4163 KiB in 5 packages
Updating package index...
 [/home/root/.vellum/local-repo]
 [https://packages.vellum.delivery]
OK: 173 distinct packages available
Installing mount-utils...
OK: 4163 KiB in 5 packages
Installing bash completion...
OK: 4163 KiB in 5 packages
PATH already configured in /home/root/.bashrc

Vellum installed successfully!
Run 'source ~/.bashrc' or start a new shell to use vellum.
```